### PR TITLE
Allow the -s argument to be supplied multiple times or singly as a space seperated list

### DIFF
--- a/bin/jgrep
+++ b/bin/jgrep
@@ -9,11 +9,7 @@ begin
     OptionParser.new do |opts|
         opts.banner = "Usage: jgrep [options] \"expression\""
         opts.on("-s", "--simple [FIELDS]", "Display only one or more fields from each of the resulting json documents") do |field|
-            if (field.split(" ")).size > 1
-                options[:field] = field.split(" ")
-            else
-                options[:field] << field
-            end
+            options[:field].concat(field.split(" "))
         end
 
         opts.on("-c", "--compact", "Display non pretty json") do


### PR DESCRIPTION
It's common in Unix to do foo -s one -s two to achieve the same as -s "one two", so now jgrep supports that too
