### PR TITLE
clarify that you need to use a space when specifying multiple fields for s flag

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -165,6 +165,7 @@ will output
     1
 
 The s flag can also be used with multiple field, which will return JSON as output which only contain the specified fields.
+**Note**: Separate fields by a space and enclose all fields in quotes (see example below) 
 
 Given:
 


### PR DESCRIPTION
make the existing howto a bit more explicit by clarifying that you need to use a space when specifying multiple fields for s flag
