### PR TITLE
Support matching boolean values.

### DIFF
--- a/lib/jgrep.rb
+++ b/lib/jgrep.rb
@@ -258,6 +258,13 @@ module JGrep
             return true
         end
 
+        # Deal with booleans
+        if tmp == true and value == 'true'
+            return true
+        elsif tmp == false and value == 'false'
+            return true
+        end
+
         #Deal with regex matching
         if ((value =~ /^\/.*\/$/) && tmp != nil)
             (tmp.match(Regexp.new(value.gsub("/", "")))) ? (return true) : (return false)


### PR DESCRIPTION
Example: echo '{"ok": true, "foo": {"ok": 5}}' | jgrep ok=true

Otherwise the value we search for (taken from the expression ok=true) is treated as string, while the value, returned by the JSON parser for the key "ok" is the boolean true. And in Ruby (true == 'true') is false.