### PR TITLE
Exit with 1 when no records found

### DIFF
--- a/bin/jgrep
+++ b/bin/jgrep
@@ -18,7 +18,8 @@ def do_grep(json, expression)
     if @options[:field].empty?
         result = JGrep::jgrep((json), expression, nil, @options[:start])
         result = result.slice(@options[:slice]) if @options[:slice]
-        unless result == [] or @options[:quiet] == true
+        exit 1 if result == []
+        unless @options[:quiet] == true
             print_json(result)
         end
     else
@@ -26,7 +27,8 @@ def do_grep(json, expression)
             JGrep::validate_filters(@options[:field])
             result = JGrep::jgrep((json), expression, @options[:field], @options[:start])
             result = result.slice(@options[:slice]) if @options[:slice]
-            unless result == [] or @options[:quiet] == true
+            exit 1 if result == []
+            unless @options[:quiet] == true
                 print_json(result)
             end
 
@@ -34,6 +36,7 @@ def do_grep(json, expression)
             JGrep::validate_filters(@options[:field][0])
             result = JGrep::jgrep((json), expression, @options[:field][0], @options[:start])
             result = result.slice(@options[:slice]) if @options[:slice]
+            exit 1 if result == []
             if result.is_a?(Array) && !(result.first.is_a?(Hash) || result.flatten.first.is_a?(Hash))
                 unless @options[:quiet] == true
                     result.map{|x| puts x unless x.nil?}


### PR DESCRIPTION
Regular `grep` exits with `1` if nothing matches, I think `jgrep` should do the same.