### PR TITLE
Handle escaped parens when tokenising statements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,4 +5,4 @@ gemspec
 gem "mocha"
 gem "rake", "< 11"
 gem "rspec"
-gem "rubocop", "~> 0.49"
+gem "rubocop", "~> 0.49.1"

--- a/lib/parser/scanner.rb
+++ b/lib/parser/scanner.rb
@@ -141,7 +141,7 @@ module JGrep
                 j += 1
               end until (j >= @arguments.size) || (chr(@arguments[j]) =~ /'|"/)
             end
-          end until (j >= @arguments.size) || (chr(@arguments[j]) =~ /\s|\)|\]/)
+          end until (j >= @arguments.size) || (chr(@arguments[j]) =~ /\s|\)|\]/ && chr(@arguments[j - 1]) != '\\')
         end
       rescue
         raise "Invalid token found - '#{current_token_value}'"

--- a/spec/unit/scanner_spec.rb
+++ b/spec/unit/scanner_spec.rb
@@ -57,6 +57,12 @@ module JGrep
         expect(token).to eq(["statement", "foo.bar=bar"])
       end
 
+      it "should identify a statement token with escaped parentheses" do
+        scanner = Scanner.new("foo.bar=/baz\\(gronk\\)quux/")
+        token = scanner.get_token
+        expect(token).to eq(["statement", "foo.bar=/baz\\(gronk\\)quux/"])
+      end
+
       it "should identify a complex array statement" do
         scanner = Scanner.new("[foo=bar and bar=foo]")
         token = scanner.get_token


### PR DESCRIPTION
This allows, for example, a statement where the value is a regex that
needs to match parentheses like `operatingsystemrelease=/^12\.2\(25\)EAW0/`