### PR TITLE
Escape period in JGrep.format float regex

### DIFF
--- a/lib/jgrep.rb
+++ b/lib/jgrep.rb
@@ -119,7 +119,7 @@ module JGrep
   def self.format(kvalue, value)
     if kvalue.to_s =~ /^\d+$/ && value.to_s =~ /^\d+$/
       [Integer(kvalue), Integer(value)]
-    elsif kvalue.to_s =~ /^\d+.\d+$/ && value.to_s =~ /^\d+.\d+$/
+    elsif kvalue.to_s =~ /^\d+\.\d+$/ && value.to_s =~ /^\d+\.\d+$/
       [Float(kvalue), Float(value)]
     else
       [kvalue, value]

--- a/spec/unit/jgrep_spec.rb
+++ b/spec/unit/jgrep_spec.rb
@@ -76,6 +76,12 @@ module JGrep
         expect(result1.is_a?(String)).to eq(true)
         expect(result2.is_a?(String)).to eq(true)
       end
+
+      it 'should not format strings with a single [^\d\.] character' do
+        result1, result2 = JGrep.format("2012R2", "2008R2")
+        expect(result1).to be_a(String)
+        expect(result2).to be_a(String)
+      end
     end
 
     describe "#has_object?" do


### PR DESCRIPTION
So that it doesn't match strings like `2012R2` as a float.

Fixes camptocamp/facterdb#148