### PR TITLE
Make spec_helper load jgrep without a relative path

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require "rubygems"
 require "rspec"
 require "rspec/mocks"
 require "mocha"
-require File.dirname(__FILE__) + "/../lib/jgrep"
+require "jgrep"
 
 RSpec.configure do |config|
   config.mock_with :mocha


### PR DESCRIPTION
When running JSON-grep's test suite from within Debian's CI
infrastructure, all tests fail because the lib directory is not placed
in the same directory as for the spec directory. This is meant to test
the code as it would be when installed via the debian package.

To fix this, we can make the require within the spec_helper file avoid
the relative path to the lib directory.

See: https://packaging.rubystyle.guide/#using-require-relative-from-test-to-lib